### PR TITLE
Fix versioned formulae.

### DIFF
--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -2,7 +2,7 @@
 layout: default
 permalink: :title
 ---
-{%- assign name = page.name | remove: ".html" -%}
+{%- assign name = page.name | remove: ".html" | remove: "@" -%}
 {%- assign f = site.data.formulae[name] -%}
 <h2>{{ f.name }}</h2>
 <p>{{ f.desc }}</p>
@@ -48,7 +48,8 @@ permalink: :title
 {%- if f.dependencies.size > 0 -%}
 <p>gcc requires the following formulae to be installed:</p>
 <table>
-    {%- for dependency_name in f.dependencies -%}
+    {%- for d in f.dependencies -%}
+    {%- assign dependency_name = d | remove: "@" -%}
     <tr>
         {%- assign dep = site.data.formulae[dependency_name] -%}
         {%- include formula.html formula=dep -%}

--- a/_layouts/formula_json.json
+++ b/_layouts/formula_json.json
@@ -1,7 +1,5 @@
 ---
 ---
-{
-  {%- assign name = page.name | remove: ".json" -%}
-  {%- assign formula = site.data.formulae[name] -%}
-  {{ name | jsonify }}: {{ formula | jsonify }}
-}
+{%- assign name = page.name | remove: ".json" | remove: "@" -%}
+{%- assign formula = site.data.formulae[name] -%}
+{{ formula | jsonify }}

--- a/api/formulae.json
+++ b/api/formulae.json
@@ -1,13 +1,11 @@
 ---
 ---
-{
-  "formulae": {
-  {%- assign sorted_formulae = site.data.formulae | sort -%}
-  {%- for formula in sorted_formulae %}
-    {{ formula[0] | jsonify }}: {{ formula[1] | jsonify }}
-    {%- unless forloop.last -%}
-    ,
-    {%- endunless -%}
+[
+{%- assign sorted_formulae = site.data.formulae | sort -%}
+{%- for formula in sorted_formulae %}
+  {{ formula[1] | jsonify }}
+  {%- unless forloop.last -%}
+  ,
+  {%- endunless -%}
   {%- endfor %}
-  }
-}
+]


### PR DESCRIPTION
Need to remove the `@` from the name to get the correct data file. Also, as a result, don't render the `@`-less name in `formulae.json` or the individual formula JSON files to avoid confusion.

Fixes #4.